### PR TITLE
chat-space DB設計 README.md記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -52,8 +52,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text|  |
 |image|string|  |
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -12,6 +12,50 @@ Things you may want to cover:
 * Configuration
 
 * Database creation
+# chat-space DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups, through: groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false,unique: true|
+
+### Association
+- has_many :users, through: groups_users
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string|null: false|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
 
 * Database initialization
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :groups, through: groups_users
+- has_many :groups_users
 
 ## groups_usersテーブル
 
@@ -44,12 +45,13 @@ Things you may want to cover:
 ### Association
 - has_many :users, through: groups_users
 - has_many :messages
+- has_many :groups_users
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
-|image|string|null: false|
+|body|text|  |
+|image|string|  |
 |group_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 


### PR DESCRIPTION
#WHAT
chat-space DB設計でREADME.mdに記載しました。

#WHY
char-spaceを作成するにあたり、DB内容を作成しておかないと都度考える必要があり、非効率のため。